### PR TITLE
Fix set logic to check for error code on failure.

### DIFF
--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -544,6 +544,8 @@ pipwerks.SCORM.data.set = function(parameter, value){
 
             } else {
 
+                errorCode = debug.getCode();
+
                 trace(traceMsgPrefix +"failed. \nError code: " +errorCode +". \nError info: " +debug.getInfo(errorCode));
 
             }


### PR DESCRIPTION
When data.set fails, currently it's currently not actually updating the default error code causing it to look as if the target LMS is failing to set data, but then returning a "No Error" code anyhow.
