### PR TITLE
Amend to look for the API in the current window first. Whilst this isn't...

### DIFF
--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -175,7 +175,9 @@ pipwerks.SCORM.API.get = function(){
         find = scorm.API.find,
         trace = pipwerks.UTILS.trace;
 
-    if(win.parent && win.parent != win){
+    API = find(win);
+
+    if(!API && win.parent && win.parent != win){
         API = find(win.parent);
     }
 


### PR DESCRIPTION
... usually required, some platforms such as Intuition Rubicon inject the API into the window due to its offline capabilities.

Also, looking in the current window is the first place to try in the original APIWrapper.js from which this was inspired. It is also referenced in the ADL guidelines.