### PR TITLE
Try/Catch Blocks around Find-Calls

### DIFF
--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -177,18 +177,36 @@ pipwerks.SCORM.API.get = function(){
 
     API = find(win);
 
-    if(!API && win.parent && win.parent != win){
-        API = find(win.parent);
+    try {
+        if (win.parent && win.parent != win) {
+            trace("Searching in window.parent for API");
+            API = find(win.parent);
+        }
+    }
+    catch (e) {
+        trace("Error while accessing window.parent: " + e);
     }
 
-    if(!API && win.top && win.top.opener){
-        API = find(win.top.opener);
+    try {
+        if (!API && win.top.opener) {
+            trace("Searching in window.top.opener for API");
+            API = find(win.top.opener);
+        }
+    }
+    catch (e) {
+        trace("Error while accessing window.top.opener: " + e);
     }
 
     //Special handling for Plateau
     //Thanks to Joseph Venditti for the patch
-    if(!API && win.top && win.top.opener && win.top.opener.document) {
-        API = find(win.top.opener.document);
+    try {
+        if (!API && win.top.opener && win.top.opener.document) {
+            trace("Searching in window.top.opener.document for API");
+            API = find(win.top.opener.document);
+        }
+    }
+    catch (e) {
+        trace("Error while accessing win.top.opener.document: " + e);
     }
 
     if(API){

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -175,7 +175,13 @@ pipwerks.SCORM.API.get = function(){
         find = scorm.API.find,
         trace = pipwerks.UTILS.trace;
 
-    API = find(win);
+    try {
+        trace("Searching in window for API");
+        API = find(win);
+    }
+    catch(e){
+        trace("Error while accessing window: " + e);
+    }
 
     try {
         if (win.parent && win.parent != win) {
@@ -411,23 +417,23 @@ pipwerks.SCORM.connection.terminate = function(){
             success = scorm.save();
 
             if(success){
-     
+
                 switch(scorm.version){
                     case "1.2" : success = makeBoolean(API.LMSFinish("")); break;
                     case "2004": success = makeBoolean(API.Terminate("")); break;
                 }
-                   
+
                 if(success){
-                        
+
                     scorm.connection.isActive = false;
-                   
+
                 } else {
-                        
+
                     errorCode = debug.getCode();
                     trace(traceMsgPrefix +"failed. \nError code: " +errorCode +" \nError info: " +debug.getInfo(errorCode));
-       
+
                 }
-                
+
             }
 
         } else {
@@ -824,9 +830,9 @@ pipwerks.SCORM.quit = pipwerks.SCORM.connection.terminate;
 pipwerks.UTILS.StringToBoolean = function(value){
     var t = typeof value;
     switch(t){
-       //typeof new String("true") === "object", so handle objects as string via fall-through. 
+       //typeof new String("true") === "object", so handle objects as string via fall-through.
        //See https://github.com/pipwerks/scorm-api-wrapper/issues/3
-       case "object":  
+       case "object":
        case "string": return (/(true|1)/i).test(value);
        case "number": return !!value;
        case "boolean": return value;


### PR DESCRIPTION
* (fix) no more "permission denied to access property API" Error when browsers cross-domain security blocks access to the target


I had the problem, that most browsers gave me "permission denied to access property API" Error when using the Scorm-Wrapper.

After some digging I found out, that the cause of this are cross-domain security properties when you open the SCO from a link that is on a different domain, than the SCO itself.

So for example:
- Create a local html-file with a link to a published/online SCO that uses the SCORM_Wrapper.
- Open the Link in a new Tab/Window
- the browser will stop when trying to access window.opener.API with "permission denied to access property API"
- the error will disappear when you close the opener Window. :/

This problem broke all my SCOs when opened from an email or different domain.
The simplest solution was to wrap all find() calls in try/catch blocks. So the code runs through and the SCORM_Wrapper isn't killing my SCOs (when no API is available).