### PR TITLE
handleSessionTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The pipwerks SCORM API Wrapper ",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node ./test/JavaScript/test.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The pipwerks SCORM API Wrapper ",
   "main": "index.js",
   "scripts": {
-    "test": "node ./test/JavaScript/test.js"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -873,6 +873,7 @@ pipwerks.UTILS.trace = function(msg){
 /* -------------------------------------------------------------------------
    pipwerks.UTILS.MillisecondsToCMIDuration()
    Converts time to scorm 1.2 time format 
+   Convert duration from milliseconds to 0000:00:00.00 format 
 
    Parameters: n (number)
    Return:     String
@@ -880,7 +881,6 @@ pipwerks.UTILS.trace = function(msg){
 
 pipwerks.UTILS.MillisecondsToCMIDuration = function(n){
 
-    //Convert duration from milliseconds to 0000:00:00.00 format 
     n = (!n || n<0)? 0 : n; //default value and force positive duration
     var hms = ""; 
     var dtm = new Date();        dtm.setTime(n); 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -387,10 +387,10 @@ pipwerks.SCORM.connection.terminate = function(){
                     //the time format is different on scorm 1.2 or 2004, so we use 
                     //different conversions depending on the case 
                     case "1.2" :
-                        this.set("cmi.core.session_time",pipwerks.UTILS.MillisecondsToCMIDuration(n)); 
+                        this.set("cmi.core.session_time",pipwerks.UTILS.msToCMIDuration(n)); 
                     break;
                     case "2004":
-                        this.set("cmi.session_time",pipwerks.UTILS.centisecsToISODuration(Math.floor(n/10)));
+                        this.set("cmi.session_time",pipwerks.UTILS.csToISODuration(Math.floor(n/10)));
                     break; 
                 }
 
@@ -871,7 +871,7 @@ pipwerks.UTILS.trace = function(msg){
 
 
 /* -------------------------------------------------------------------------
-   pipwerks.UTILS.MillisecondsToCMIDuration()
+   pipwerks.UTILS.msToCMIDuration()
    Converts time to scorm 1.2 time format 
    Convert duration from milliseconds to 0000:00:00.00 format 
 
@@ -879,7 +879,7 @@ pipwerks.UTILS.trace = function(msg){
    Return:     String
 ---------------------------------------------------------------------------- */
 
-pipwerks.UTILS.MillisecondsToCMIDuration = function(n){
+pipwerks.UTILS.msToCMIDuration = function(n){
 
     n = (!n || n < 0)? 0 : n; //default value and force positive duration
     var hms = ""; 
@@ -895,14 +895,14 @@ pipwerks.UTILS.MillisecondsToCMIDuration = function(n){
 
 
 /* -------------------------------------------------------------------------
-   pipwerks.UTILS.centisecsToISODuration()
+   pipwerks.UTILS.csToISODuration()
    Converts time to scorm 2004 time format
 
    Parameters: n (number)
    Return:     String
 ---------------------------------------------------------------------------- */
 
-pipwerks.UTILS.centisecsToISODuration = function(n){ 
+pipwerks.UTILS.csToISODuration = function(n){ 
 
     // Note: SCORM and IEEE 1484.11.1 require centisec precision 
     // Months calculated by approximation based on average number 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -33,6 +33,7 @@ pipwerks.SCORM = {                                  //Define the SCORM object
     version:    null,                               //Store SCORM version.
     handleCompletionStatus: true,                   //Whether or not the wrapper should automatically handle the initial completion status
     handleExitMode: true,                           //Whether or not the wrapper should automatically handle the exit mode
+    handleSessionTime: true,                        //Whether or not the wrapper should automatically handle the session time	
     API:        { handle: null,
                   isFound: false },                 //Create API child object
     connection: { isActive: false },                //Create connection child object

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -387,11 +387,9 @@ pipwerks.SCORM.connection.terminate = function(){
                     //the time format is different on scorm 1.2 or 2004, so we use 
                     //different conversions depending on the case 
                     case "1.2" :
-                        //success = this.set("cmi.core.session_time",MillisecondsToCMIDuration(n)); 
                         this.set("cmi.core.session_time",pipwerks.UTILS.MillisecondsToCMIDuration(n)); 
                     break;
                     case "2004":
-                        //success = this.set("cmi.session_time",centisecsToISODuration(Math.floor(n/10)));
                         this.set("cmi.session_time",pipwerks.UTILS.centisecsToISODuration(Math.floor(n/10)));
                     break; 
                 }

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -253,6 +253,9 @@ pipwerks.SCORM.connection.initialize = function(){
 
     trace("connection.initialize called.");
 
+    //set init date-time
+    scorm.data.dtmInitialized = new Date();
+	
     if(!scorm.connection.isActive){
 
         var API = scorm.API.getHandle(),

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -38,7 +38,8 @@ pipwerks.SCORM = {                                  //Define the SCORM object
                   isFound: false },                 //Create API child object
     connection: { isActive: false },                //Create connection child object
     data:       { completionStatus: null,
-                  exitStatus: null },               //Create data child object
+                  exitStatus: null,
+                  dtmInitialized: null},             //Create data child object
     debug:      {}                                  //Create debug child object
 };
 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -881,6 +881,7 @@ pipwerks.UTILS.trace = function(msg){
 pipwerks.UTILS.MillisecondsToCMIDuration = function(n){
 
     //Convert duration from milliseconds to 0000:00:00.00 format 
+    n = (!n || n<0)? 0 : n; //default value and force positive duration
     var hms = ""; 
     var dtm = new Date();        dtm.setTime(n); 
     var h = "0" + Math.floor(n / 3600000); 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -33,7 +33,7 @@ pipwerks.SCORM = {                                  //Define the SCORM object
     version:    null,                               //Store SCORM version.
     handleCompletionStatus: true,                   //Whether or not the wrapper should automatically handle the initial completion status
     handleExitMode: true,                           //Whether or not the wrapper should automatically handle the exit mode
-    handleSessionTime: true,                        //Whether or not the wrapper should automatically handle the session time	
+    handleSessionTime: false,                        //Whether or not the wrapper should automatically handle the session time
     API:        { handle: null,
                   isFound: false },                 //Create API child object
     connection: { isActive: false },                //Create connection child object

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -387,7 +387,7 @@ pipwerks.SCORM.connection.terminate = function(){
                     //the time format is different on scorm 1.2 or 2004, so we use 
                     //different conversions depending on the case 
                     case "1.2" :
-                        this.set("cmi.core.session_time",pipwerks.UTILS.msToCMIDuration(n)); 
+                        this.set("cmi.core.session_time",pipwerks.UTILS.msToCMIDuration(n));
                     break;
                     case "2004":
                         this.set("cmi.session_time",pipwerks.UTILS.csToISODuration(Math.floor(n/10)));
@@ -883,13 +883,13 @@ pipwerks.UTILS.msToCMIDuration = function(n){
 
     n = (!n || n < 0)? 0 : n; //default value and force positive duration
     var hms = ""; 
-    var dtm = new Date();        dtm.setTime(n); 
-    var h = "0" + Math.floor(n / 3600000); 
-    var m = "0" + dtm.getMinutes(); 
-    var s = "0" + dtm.getSeconds(); 
-    hms = h.substr(h.length - 2) + ":"+ m.substr(m.length - 2) + ":"; 
-    hms += s.substr(s.length - 2); 
-    return hms 
+    var dtm = new Date();        dtm.setTime(n);
+    var h = "0" + Math.floor(n / 3600000);
+    var m = "0" + dtm.getMinutes();
+    var s = "0" + dtm.getSeconds();
+    hms = h.substr(h.length - 2) + ":"+ m.substr(m.length - 2) + ":";
+    hms += s.substr(s.length - 2);
+    return hms;
 
 };
 
@@ -902,46 +902,46 @@ pipwerks.UTILS.msToCMIDuration = function(n){
    Return:     String
 ---------------------------------------------------------------------------- */
 
-pipwerks.UTILS.csToISODuration = function(n){ 
+pipwerks.UTILS.csToISODuration = function(n){
 
-    // Note: SCORM and IEEE 1484.11.1 require centisec precision 
-    // Months calculated by approximation based on average number 
-    // of days over 4 years (365*4+1), not counting the extra day 
-    // every 1000 years. If a reference date was available, 
-    // the calculation could be more precise, but becomes complex, 
-    // since the exact result depends on where the reference date 
-    // falls within the period (e.g. beginning, end or ???) 
-    // 1 year ~ (365*4+1)/4*60*60*24*100 = 3155760000 centiseconds 
-    // 1 month ~ (365*4+1)/48*60*60*24*100 = 262980000 centiseconds 
-    // 1 day = 8640000 centiseconds 
-    // 1 hour = 360000 centiseconds 
-    // 1 minute = 6000 centiseconds 
-    n = Math.max(n,0); // there is no such thing as a negative duration 
-    var str = "P"; 
-    var nCs = n; 
-    // Next set of operations uses whole seconds 
-    var nY = Math.floor(nCs / 3155760000); 
-    nCs -= nY * 3155760000; 
-    var nM = Math.floor(nCs / 262980000); 
-    nCs -= nM * 262980000; 
-    var nD = Math.floor(nCs / 8640000); 
-    nCs -= nD * 8640000; 
-    var nH = Math.floor(nCs / 360000); 
-    nCs -= nH * 360000; 
-    var nMin = Math.floor(nCs /6000); 
-    nCs -= nMin * 6000 
-    // Now we can construct string 
-    if (nY > 0) str += nY + "Y"; 
-    if (nM > 0) str += nM + "M"; 
-    if (nD > 0) str += nD + "D"; 
-    if ((nH > 0) || (nMin > 0) || (nCs > 0)) { 
-        str += "T"; 
-        if (nH > 0) str += nH + "H"; 
-        if (nMin > 0) str += nMin + "M"; 
-        if (nCs > 0) str += (nCs / 100) + "S"; 
-    } 
-    if (str == "P") str = "PT0H0M0S"; 
-      // technically PT0S should do but SCORM test suite assumes longer form. 
+    // Note: SCORM and IEEE 1484.11.1 require centisec precision
+    // Months calculated by approximation based on average number
+    // of days over 4 years (365*4+1), not counting the extra day
+    // every 1000 years. If a reference date was available,
+    // the calculation could be more precise, but becomes complex,
+    // since the exact result depends on where the reference date
+    // falls within the period (e.g. beginning, end or ???)
+    // 1 year ~ (365*4+1)/4*60*60*24*100 = 3155760000 centiseconds
+    // 1 month ~ (365*4+1)/48*60*60*24*100 = 262980000 centiseconds
+    // 1 day = 8640000 centiseconds
+    // 1 hour = 360000 centiseconds
+    // 1 minute = 6000 centiseconds
+    n = Math.max(n,0); // there is no such thing as a negative duration
+    var str = "P";
+    var nCs = n;
+    // Next set of operations uses whole seconds
+    var nY = Math.floor(nCs / 3155760000);
+    nCs -= nY * 3155760000;
+    var nM = Math.floor(nCs / 262980000);
+    nCs -= nM * 262980000;
+    var nD = Math.floor(nCs / 8640000);
+    nCs -= nD * 8640000;
+    var nH = Math.floor(nCs / 360000);
+    nCs -= nH * 360000;
+    var nMin = Math.floor(nCs /6000);
+    nCs -= nMin * 6000;
+    // Now we can construct string
+    if (nY > 0) str += nY + "Y";
+    if (nM > 0) str += nM + "M";
+    if (nD > 0) str += nD + "D";
+    if ((nH > 0) || (nMin > 0) || (nCs > 0)) {
+        str += "T";
+        if (nH > 0) str += nH + "H";
+        if (nMin > 0) str += nMin + "M";
+        if (nCs > 0) str += (nCs / 100) + "S";
+    }
+    if (str == "P") str = "PT0H0M0S";
+      // technically PT0S should do but SCORM test suite assumes longer form.
     return str;
 
 };

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -881,14 +881,14 @@ pipwerks.UTILS.trace = function(msg){
 
 pipwerks.UTILS.MillisecondsToCMIDuration = function(n){
 
-    n = (!n || n<0)? 0 : n; //default value and force positive duration
+    n = (!n || n < 0)? 0 : n; //default value and force positive duration
     var hms = ""; 
     var dtm = new Date();        dtm.setTime(n); 
     var h = "0" + Math.floor(n / 3600000); 
     var m = "0" + dtm.getMinutes(); 
     var s = "0" + dtm.getSeconds(); 
-    hms = h.substr(h.length-2)+":"+m.substr(m.length-2)+":"; 
-    hms += s.substr(s.length-2); 
+    hms = h.substr(h.length - 2) + ":"+ m.substr(m.length - 2) + ":"; 
+    hms += s.substr(s.length - 2); 
     return hms 
 
 };
@@ -938,7 +938,7 @@ pipwerks.UTILS.centisecsToISODuration = function(n){
         str += "T"; 
         if (nH > 0) str += nH + "H"; 
         if (nMin > 0) str += nMin + "M"; 
-                if (nCs > 0) str += (nCs / 100) + "S"; 
+        if (nCs > 0) str += (nCs / 100) + "S"; 
     } 
     if (str == "P") str = "PT0H0M0S"; 
       // technically PT0S should do but SCORM test suite assumes longer form. 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -379,7 +379,7 @@ pipwerks.SCORM.connection.terminate = function(){
 
                 var dtm = new Date(); 
 
-                //in the next line you substract the time recorded when initialising 
+                //in the next line you subtract the time recorded when initialising 
                 //the connection from the present time. 
                 var n = dtm.getTime() - dtmInitialized.getTime(); 
                 switch(scorm.version){ 

--- a/src/JavaScript/SCORM_API_wrapper.js
+++ b/src/JavaScript/SCORM_API_wrapper.js
@@ -896,7 +896,7 @@ pipwerks.UTILS.msToCMIDuration = function(n){
 
 /* -------------------------------------------------------------------------
    pipwerks.UTILS.csToISODuration()
-   Converts time to scorm 2004 time format
+   Converts time to scorm 2004 time format using ISO 8601
 
    Parameters: n (number)
    Return:     String

--- a/test/JavaScript/index.html
+++ b/test/JavaScript/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width">
+        <title>SCORM_API_wrapper.js - tests</title>
+        <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-2.4.1.css">
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+        <script src="../../src/JavaScript/SCORM_API_wrapper.js"></script>
+        <script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
+        <script src="test.js"></script>
+    </body>
+</html>

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -1,31 +1,31 @@
-QUnit.test("centisecsToISODuration", function (assert){
+QUnit.test("csToISODuration", function (assert){
 
     var t1 = 1513937992632;
     var t2 = 1513938095752;
     var d = t2 - t1;
 
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(d), 'PT17M11.2S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(undefined), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(null), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(''), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(0), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(-1), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(d), 'PT17M11.2S');
+    assert.equal(pipwerks.UTILS.csToISODuration(), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(undefined), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(null), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(''), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(0), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(-1), 'PT0H0M0S');
 
 });
 
-QUnit.test("MillisecondsToCMIDuration", function (assert) {
+QUnit.test("msToCMIDuration", function (assert) {
 
     var t1 = 1513937992632;
     var t2 = 1513938095752;
     var d = t2 - t1;
 
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(d), '00:01:43');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(), '00:00:00');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(undefined), '00:00:00');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(null), '00:00:00');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(''), '00:00:00');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(0), '00:00:00');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(-1), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(d), '00:01:43');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(undefined), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(null), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(''), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(0), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(-1), '00:00:00');
 
 });

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -1,31 +1,31 @@
 QUnit.test("csToISODuration", function (assert){
 
-    var t1 = 1513937992632;
-    var t2 = 1513938095752;
-    var d = t2 - t1;
-
-    assert.equal(pipwerks.UTILS.csToISODuration(d), 'PT17M11.2S');
-    assert.equal(pipwerks.UTILS.csToISODuration(), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.csToISODuration(undefined), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.csToISODuration(null), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.csToISODuration(''), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.csToISODuration(0), 'PT0H0M0S');
-    assert.equal(pipwerks.UTILS.csToISODuration(-1), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.csToISODuration(100), 'PT1S', 'check result for 1 second');
+    assert.equal(pipwerks.UTILS.csToISODuration(100 * 61), 'PT1M1S', 'check result for 1 minute and 1 second');
+    assert.equal(pipwerks.UTILS.csToISODuration(100 * 60 * 15), 'PT15M', 'check result for 15 minutes');
+    assert.equal(pipwerks.UTILS.csToISODuration(100 * 60 * 90), 'PT1H30M', 'check result for 1 hour and 30 minutes');
+    assert.equal(pipwerks.UTILS.csToISODuration(100 * 60 * 60 * 24 + 100 * 60 * 37 + 100 * 25), 'P1DT37M25S', 'check result for 1 day 37 minutes and 25 seconds');
+    assert.equal(pipwerks.UTILS.csToISODuration(), 'PT0H0M0S', 'check no arguments is correctly handled');
+    assert.equal(pipwerks.UTILS.csToISODuration(undefined), 'PT0H0M0S', 'check undefined is correctly handled');
+    assert.equal(pipwerks.UTILS.csToISODuration(null), 'PT0H0M0S', 'check null is correctly handled');
+    assert.equal(pipwerks.UTILS.csToISODuration(''), 'PT0H0M0S', 'check string is correctly handled');
+    assert.equal(pipwerks.UTILS.csToISODuration(0), 'PT0H0M0S', 'check 0 is correctly handled');
+    assert.equal(pipwerks.UTILS.csToISODuration(-1), 'PT0H0M0S', 'check negative numbers are correctly handled');
 
 });
 
 QUnit.test("msToCMIDuration", function (assert) {
 
-    var t1 = 1513937992632;
-    var t2 = 1513938095752;
-    var d = t2 - t1;
-
-    assert.equal(pipwerks.UTILS.msToCMIDuration(d), '00:01:43');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(), '00:00:00');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(undefined), '00:00:00');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(null), '00:00:00');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(''), '00:00:00');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(0), '00:00:00');
-    assert.equal(pipwerks.UTILS.msToCMIDuration(-1), '00:00:00');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(1000), '00:00:01', 'check result for 1 second');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(1000 * 61), '00:01:01', 'check result for 1 minute and 1 second');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(1000 * 60 * 15), '00:15:00', 'check result for 15 minutes');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(1000 * 60 * 90), '01:30:00', 'check result for 1 hour and 30 minutes');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(1000 * 60 * 60 * 24 + 1000 * 60 * 37 + 1000 * 25), '24:37:25', 'check result for 1 day 37 minutes and 25 seconds');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(), '00:00:00', 'check no arguments is correctly handled');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(undefined), '00:00:00', 'check undefined is correctly handled');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(null), '00:00:00', 'check null is correctly handled');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(''), '00:00:00', 'check string is correctly handled');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(0), '00:00:00', 'check 0 is correctly handled');
+    assert.equal(pipwerks.UTILS.msToCMIDuration(-1), '00:00:00', 'check negative numbers are correctly handled');
 
 });

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -5,6 +5,11 @@ QUnit.test("centisecsToISODuration", function (assert){
     var d = t2 - t1;
 
     assert.equal(pipwerks.UTILS.centisecsToISODuration(d), 'PT17M11.2S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(undefined), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(null), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(''), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(0), 'PT0H0M0S');
 
 });
 
@@ -15,5 +20,10 @@ QUnit.test("MillisecondsToCMIDuration", function (assert) {
     var d = t2 - t1;
 
     assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(d), '00:01:43');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(), '00:00:00');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(undefined), '00:00:00');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(null), '00:00:00');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(''), '00:00:00');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(0), '00:00:00');
 
 });

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+var pipwerks = require('../../src/JavaScript/SCORM_API_wrapper.js');
+
+try{
+
+    let t1 = 1513937992632;
+    let t2 = 1513938095752;
+    let d = t2 - t1;
+
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(d),'PT17M11.2S');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(d),'00:01:43');
+
+    console.log('All tests passed!');
+
+}
+catch(e){
+    console.log(e);
+}

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -10,6 +10,7 @@ QUnit.test("centisecsToISODuration", function (assert){
     assert.equal(pipwerks.UTILS.centisecsToISODuration(null), 'PT0H0M0S');
     assert.equal(pipwerks.UTILS.centisecsToISODuration(''), 'PT0H0M0S');
     assert.equal(pipwerks.UTILS.centisecsToISODuration(0), 'PT0H0M0S');
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(-1), 'PT0H0M0S');
 
 });
 
@@ -25,5 +26,6 @@ QUnit.test("MillisecondsToCMIDuration", function (assert) {
     assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(null), '00:00:00');
     assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(''), '00:00:00');
     assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(0), '00:00:00');
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(-1), '00:00:00');
 
 });

--- a/test/JavaScript/test.js
+++ b/test/JavaScript/test.js
@@ -1,18 +1,19 @@
-var assert = require('assert');
-var pipwerks = require('../../src/JavaScript/SCORM_API_wrapper.js');
+QUnit.test("centisecsToISODuration", function (assert){
 
-try{
+    var t1 = 1513937992632;
+    var t2 = 1513938095752;
+    var d = t2 - t1;
 
-    let t1 = 1513937992632;
-    let t2 = 1513938095752;
-    let d = t2 - t1;
+    assert.equal(pipwerks.UTILS.centisecsToISODuration(d), 'PT17M11.2S');
 
-    assert.equal(pipwerks.UTILS.centisecsToISODuration(d),'PT17M11.2S');
-    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(d),'00:01:43');
+});
 
-    console.log('All tests passed!');
+QUnit.test("MillisecondsToCMIDuration", function (assert) {
 
-}
-catch(e){
-    console.log(e);
-}
+    var t1 = 1513937992632;
+    var t2 = 1513938095752;
+    var d = t2 - t1;
+
+    assert.equal(pipwerks.UTILS.MillisecondsToCMIDuration(d), '00:01:43');
+
+});


### PR DESCRIPTION
Hi!

I've been using this for years, since some LMS platforms does not handle automatically the session time I have added an option for the wrapper to handle it. Maybe someone would find it helpful too.

If you dont mind, could you pull it? I have followed the same approach as other options like "handleCompletionStatus", adapt it as you consider.

Keep in touch!
Thanks.